### PR TITLE
Adding command line option for paper format

### DIFF
--- a/src/paper_format.py
+++ b/src/paper_format.py
@@ -19,3 +19,9 @@ class PaperFormat(Enum):
     '''
     LETTER = PaperSize('US Letter', 8.5, 11.0)
     LEGAL = PaperSize('US Legal', 8.5, 14.0)
+
+    @staticmethod
+    def get(key):
+        # Helper method to get enum from lower case string
+        return PaperFormat[key.upper()]
+

--- a/src/parse_args.py
+++ b/src/parse_args.py
@@ -1,10 +1,13 @@
 from argparse import ArgumentParser
+from src.paper_format import PaperFormat
 
 def parse_args():
     '''
     Parse command line arguments using argparse
     '''
-    parser = ArgumentParser()
+    parser = ArgumentParser(
+        description=('Create a flipbook from a video file by extracting frames and arranging them'
+                     ' on specific paper type for printing'))
     parser.add_argument('filename', help='Path of the video file to use')
     parser.add_argument('output_dir', help='Directory to write output')
     parser.add_argument('output_base_name', nargs='?', default=None,
@@ -12,5 +15,8 @@ def parse_args():
                               '(default None -> use stem of the input video file)'))
     parser.add_argument('-fr', '--output-frame-rate', type=float, default=3.0,
                         help=('Output frame rate for flipbook in fps (default 3.0fps)'))
+    # Get the list of options for paper type from the PaperFormat enum
+    paper_formats = [e.name.lower() for e in PaperFormat]
+    parser.add_argument('-p', '--paper-type', choices=paper_formats, default='letter')
     args = parser.parse_args()
     return args

--- a/src/parse_args.py
+++ b/src/parse_args.py
@@ -17,6 +17,6 @@ def parse_args():
                         help=('Output frame rate for flipbook in fps (default 3.0fps)'))
     # Get the list of options for paper type from the PaperFormat enum
     paper_formats = [e.name.lower() for e in PaperFormat]
-    parser.add_argument('-p', '--paper-type', choices=paper_formats, default='letter')
+    parser.add_argument('-p', '--paper-format', choices=paper_formats, default='letter')
     args = parser.parse_args()
     return args


### PR DESCRIPTION
Add paper-format as command line option

Not used yet, but this will eventually allow for ability for user to specify flipbook output size and lay out the flipbook frames on the paper accordingly