### PR TITLE
Combine individual pdf pages into a single PDF document

### DIFF
--- a/create_flipbook.py
+++ b/create_flipbook.py
@@ -9,7 +9,6 @@ def main():
     flipbook = Flipbook(
         args.filename,
         args.output_dir,
-        output_base_name=args.output_base_name,
         output_frame_rate=args.output_frame_rate)
 
     # Print the info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pillow
 opencv-python
+pypdf # to combine individual PDF pages into one document
+

--- a/src/flipbook.py
+++ b/src/flipbook.py
@@ -5,9 +5,10 @@ import cv2
 from PIL import Image
 from PIL import ImageFont
 from PIL import ImageDraw
+from pypdf import PdfMerger
 
 from src.flipbook_constants import FlipbookConstants
-from src.input_video import InputVideo
+from src.input_format import InputFormat
 from src.output_format import OutputFormat
 from src.paper_type import PaperType
 
@@ -16,13 +17,21 @@ class Flipbook:
     '''
     Class to create frames for flipbook from video file
     '''
-    FRAME_BASE_NAME = 'video_frame'
 
-    def __init__(self, filename, output_dir, output_base_name=None, ncols=3, nrows=3, output_frame_rate=0):
+    def __init__(
+            self,
+            filename,
+            output_dir,
+            output_base_name=None,
+            ncols=3,
+            nrows=3,
+            output_frame_rate=0,
+            frame_border_padding=50,
+            left_binding_padding=260,
+             ):
+
         # video file name
-        self.n_flipbook_frames = None
-        self.input_video = InputVideo(filename)
-        self.output_format = OutputFormat(nrows, ncols, output_frame_rate, PaperType.LETTER)
+        self.input_video = InputFormat(filename)
 
         # output directory for output for flipbook
         self.output_dir = output_dir
@@ -31,8 +40,17 @@ class Flipbook:
         # (default -> same base as the input video)
         self.output_base_name = self.validate_base_name(output_base_name)
 
-        # Initialize number of frames in flipbook
-        # self.n_flipbook_frames = self.input_video.total_frames // self.to_process
+        self.output_format = OutputFormat(
+                                nrows,
+                                ncols,
+                                output_frame_rate,
+                                PaperType.LETTER,
+                                frame_border_padding,
+                                left_binding_padding,
+                            )
+
+        self.n_flipbook_frames = None
+
 
     def print_info(self):
         print('\n\n----------------------------')
@@ -61,12 +79,6 @@ class Flipbook:
         output_dir_path.mkdir()
         del output_dir_path
         return True
-
-    def get_frame_jpg_name(self, frame_no):
-        return Path(self.output_dir).joinpath(Path(f'{self.FRAME_BASE_NAME}.{str(frame_no)}.jpg'))
-
-    def get_frame_pdf_name(self, frame_no):
-        return Path(self.output_dir).joinpath(Path(f'{self.FRAME_BASE_NAME}.{str(frame_no)}.pdf'))
 
     def extract_frames(self):
         # Input and output frame rates
@@ -193,6 +205,7 @@ class Flipbook:
             # Get subset of frames for the batch
             frames_in_batch = self.frames[batch_no * num_per_page: (batch_no + 1) * num_per_page]
             self.write_tiled_batch(frames_in_batch, batch_no)
+
         del self.frames
         filenames = '\n'.join([str(self.get_output_name(batch_no)) for batch_no in range(num_pages_to_print)])
         print(f'\n\nWrote the following pages:\n{filenames}')

--- a/src/flipbook.py
+++ b/src/flipbook.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from math import ceil
 from tqdm import tqdm
@@ -5,7 +6,7 @@ import cv2
 from PIL import Image
 from PIL import ImageFont
 from PIL import ImageDraw
-from pypdf import PdfMerger
+from pypdf import PdfWriter
 
 from src.flipbook_constants import FlipbookConstants
 from src.input_format import InputFormat
@@ -22,7 +23,6 @@ class Flipbook:
             self,
             filename,
             output_dir,
-            output_base_name=None,
             ncols=3,
             nrows=3,
             output_frame_rate=0,
@@ -35,10 +35,6 @@ class Flipbook:
 
         # output directory for output for flipbook
         self.output_dir = output_dir
-
-        # base name for output files for flipbook
-        # (default -> same base as the input video)
-        self.output_base_name = self.validate_base_name(output_base_name)
 
         self.output_format = OutputFormat(
                                 nrows,
@@ -64,20 +60,42 @@ class Flipbook:
         print('----------------------------\n\n')
 
 
-    def validate_base_name(self, output_base_name):
-        if output_base_name is not None:
-            return output_base_name
-        return Path(self.input_video.filename).stem
+    def pad(self):
+        return self.output_format.frame_border_padding
 
-    def create_data_dir(self):
+    def left_pad(self):
+        return self.output_format.left_binding_padding
+
+    def frame_width(self):
+        return self.input_video.width
+
+    def frame_height(self):
+        return self.input_video.height
+
+    def ncols(self):
+        return self.output_format.ncols
+
+    def nrows(self):
+        return self.output_format.nrows
+
+    def grid_width(self):
+        return int((self.frame_width() + 2 * self.pad() + self.left_pad()) * self.ncols())
+
+    def grid_height(self):
+        return int((self.frame_height() + 2 * self.pad()) * self.nrows())
+
+    def create_output_dir(self):
         output_dir_path = Path(self.output_dir)
         if Path.exists(output_dir_path):
             if output_dir_path.is_dir():
+                if os.listdir(self.output_dir):
+                    raise Exception((f'Output directory {self.output_dir} '
+                                     'already exists and is nonempty.'))
                 return True
-            raise Exception(f'Expected data output directory path {self.output_dir} exists but is not a directory.')
+            raise Exception((f'Expected data output directory path {self.output_dir}'
+                             ' exists but is not a directory.'))
         # If the data_dir does not exist, crate it
         output_dir_path.mkdir()
-        del output_dir_path
         return True
 
     def extract_frames(self):
@@ -89,11 +107,11 @@ class Flipbook:
         cam = cv2.VideoCapture(self.input_video.filename)
 
         # Create a directory for the extracted frames
-        self.create_data_dir()
+        self.create_output_dir()
 
         # Cycle through the frames
         index_out = 0
-        self.frames = []
+        frames = []
         for index_in in range(self.input_video.total_frames):
             # Read the frame
             success, frame = cam.read()
@@ -112,15 +130,26 @@ class Flipbook:
                     self.input_video.total_frames = index_in
                     break
                 # otherwise we process the frame
-                self.frames.append(frame)
+                frames.append(frame)
                 index_out += 1
 
         self.n_flipbook_frames = index_out
         cam.release()
         cv2.destroyAllWindows()
+        return frames
 
-    def get_output_name(self, batch_no):
-        return Path(self.output_dir).joinpath(Path(f'{self.output_base_name}.{str(batch_no)}.pdf'))
+    def get_base_output_name(self):
+        '''
+        Base file name is based on input file name
+        '''
+        return Path(self.input_video.filename).stem
+
+    def get_output_name(self, batch_no=None):
+        if batch_no is None:
+            filename = f'{self.get_base_output_name()}.pdf'
+        else:
+            filename = f'{self.get_base_output_name()}.{str(batch_no)}.pdf'
+        return Path(self.output_dir).joinpath(Path(filename))
 
     def add_watermark_to_img(self, img, watermark_text):
         # https://www.tutorialspoint.com/python_pillow/python_pillow_creating_a_watermark.htm
@@ -165,31 +194,7 @@ class Flipbook:
 
         grid.save(batch_filename)
 
-    def pad(self):
-        return self.output_format.frame_border_padding
-
-    def left_pad(self):
-        return self.output_format.left_binding_padding
-
-    def frame_width(self):
-        return self.input_video.width
-
-    def frame_height(self):
-        return self.input_video.height
-
-    def ncols(self):
-        return self.output_format.ncols
-
-    def nrows(self):
-        return self.output_format.nrows
-
-    def grid_width(self):
-        return int((self.frame_width() + 2 * self.pad() + self.left_pad()) * self.ncols())
-
-    def grid_height(self):
-        return int((self.frame_height() + 2 * self.pad()) * self.nrows())
-
-    def write_output(self):
+    def write_output_pdfs(self, frames):
         # total number of images per page
         num_per_page = self.output_format.nrows * self.output_format.ncols
 
@@ -203,16 +208,31 @@ class Flipbook:
                 desc=f'Writing output to {self.output_dir}/'
             ):
             # Get subset of frames for the batch
-            frames_in_batch = self.frames[batch_no * num_per_page: (batch_no + 1) * num_per_page]
+            frames_in_batch = frames[batch_no * num_per_page: (batch_no + 1) * num_per_page]
             self.write_tiled_batch(frames_in_batch, batch_no)
 
-        del self.frames
-        filenames = '\n'.join([str(self.get_output_name(batch_no)) for batch_no in range(num_pages_to_print)])
-        print(f'\n\nWrote the following pages:\n{filenames}')
+        print()
+        return [self.get_output_name(batch_no) for batch_no in range(num_pages_to_print)]
+
+    def combine_pdfs(self, output_frames):
+        output_file_name = self.get_output_name(None)
+        merger = PdfWriter()
+        for page in output_frames:
+            merger.append(page)
+
+        merger.write(output_file_name)
+        merger.close()
+        for page in output_frames:
+            os.remove(page)
+        print(f'\nWrote {output_file_name}\n\n')
+
+    def write_output(self, frames):
+        output_frames = self.write_output_pdfs(frames)
+        self.combine_pdfs(output_frames)
 
     def run(self):
         # Read the video and extract the frames
-        self.extract_frames()
+        frames = self.extract_frames()
 
         # Write the PDFs to output files
-        self.write_output()
+        self.write_output(frames)

--- a/src/input_format.py
+++ b/src/input_format.py
@@ -3,7 +3,7 @@ import cv2
 from src.flipbook_constants import FlipbookConstants
 
 
-class InputVideo:
+class InputFormat:
     '''
     Class owning info about the input video file
     including file validation and metadata gathering

--- a/src/output_format.py
+++ b/src/output_format.py
@@ -12,7 +12,7 @@ class OutputFormat:
     flipbook dimension and work backwards to calculate how many frames
     will fit per page,
     '''
-    def __init__(self, nrows, ncols, frame_rate, paper_format, frame_border_padding=50, left_binding_padding=260):
+    def __init__(self, nrows, ncols, frame_rate, paper_format, frame_border_padding, left_binding_padding):
         # Number of rows and columns to arrange flipbook frames in a page
         self.nrows = nrows
         self.ncols = ncols


### PR DESCRIPTION
Each individual page of tiled frames of the flipbook is written out as a PDF document.

This change combines the individual PDFs into one multi-page PDF document. 

The individual page PDFs are treated as temporary files, and are deleted from disk once the merged PDF is created.