### PR TITLE
improve script stdout readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,26 @@ The script requires the following positional arguments:
 * [Optional] A base name for the output files
 
 Also there are the following options:
+Frame extraction settings:
 * -fr (--output-frame-rate): The frame rate at which the video frames will be extracted
+* -W (--width): The width of the resulting flipbook
+* -H (--height): The height of the resulting flipbook
+
+Paper settings:
 * -p (--paper-type): The paper type on which to print the flipbook frames (currently US Letter ad US Legal are options)
+* -d (--dpi): The dots per inch being printed
+
+Flipbook frame formatting settings:
+* -bp (--border-padding): Padding to be applied equally to all sides of frame image
+* -lp (--left-padding): Additional padding to be applied to the left side of the frame (for binding)
+* -lw (--border-line-width): width of the line for the border drawn around each frame
 
 # Running the script
 
 Examples:
 
 ```
-python create_flipbook.py input_videos/steamboat_willie.mov flipbook_output/mickey --frame-rate 10
+python create_flipbook.py input_videos/steamboat_willie_mickey.mov flipbook_output/mickey --output-frame-rate 3 --width 5 --height 3 --border-padding 30 --left-padding 180 --border-line-width 3
 ```
 Output is the following:
 
@@ -33,29 +44,44 @@ Output is the following:
 ----------------------------
 Input Video Info
 ----------------------------
-Input file: input_videos/steamboat_willie.mov
+Input file: input_videos/steamboat_willie_mickey.mov
 Resolution: 1726.0x1298.0
 Frame rate: 59.34 fps
 
 ----------------------------
-Output Formatting Info
+Output Flipbook Format
 ----------------------------
-ncols: 3
-nrows: 3
-Frame rate: 10.00 fps
-Page format: US Letter
-Page aspect ratio: 1.29
-Frame border padding: 50
-Left binding padding: 260
+Flipbook frame size: 1500x900
+border_padding: 30
+left_padding: 180
+border_line_width: 3
+
+
+Extracting frames from input_videos/steamboat_willie_mickey.mov at 3.0 FPS
+ 98%|█████████████████████████████████████████████████████████████████████████▊ | 441/448 [00:02<00:00, 175.54it/s]
+   ...Stopping extraction at frame 441.
+   ...Done extracting frames.
+
+
+Saving printable flipbook to flipbook_output/mickey with paper type letter at 300 DPI.
+----------------------------
+Printable Flipbook Specs
+----------------------------
+Printed page type: US Letter
+Printed page size (inches): 11.0x8.5
+Printed page size (pixels): 3300x2550
+Printed page dpi: 300
+Frames per page: 2x2
+Pages to print: 6
+Output file: flipbook_output/mickey/steamboat_willie_mickey.pdf
 ----------------------------
 
 
-Num pages: 9
-Writing output to flipbook_output/mickey/: 100%|██████████████████████████| 9/9 [00:04<00:00,  2.19it/s]
+Saving printable flipbook: 100%|█████████████████████████████████████████████████████| 6/6 [00:02<00:00,  2.67it/s]
 
 
-Wrote the following PDF:
-flipbook_output/mickey/steamboat_willie.pdf
+Wrote flipbook_output/mickey/steamboat_willie_mickey.pdf
+
 ```
 
 

--- a/src/core/flipbook.py
+++ b/src/core/flipbook.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import cv2
+from tqdm import tqdm
 
 from src.media.canvas import Canvas
 from src.core.frame import Frame
@@ -57,12 +58,10 @@ class Flipbook:
         """
         success = cam.grab()
         if not success:
-            print(f"Stopping extraction at frame {index_in}.\n")
             return None
 
         success, data = cam.retrieve()
         if not success:
-            print(f"Stopping extraction at frame {index_in}.\n")
             return None
 
         return data
@@ -75,11 +74,14 @@ class Flipbook:
         :return: list of raw frame data.
         """
         frame_data = []
-        for index_in in range(self.video_source.total_frames):
+        for frame_no, index_in in enumerate(tqdm(range(self.video_source.total_frames))):
             data = self.capture_frame(cam, index_in)
             if data is None:
                 break
             frame_data.append(data)
+        if frame_no < self.video_source.total_frames:
+            print(f"   ...Stopping extraction at frame {frame_no}.")
+        print(f'   ...Done extracting frames.\n\n')
         return frame_data
 
     def process_frame(self, data, cur_frame_no, canvas) -> Frame:
@@ -120,9 +122,9 @@ class Flipbook:
         print('Output Flipbook Format')
         print('----------------------------')
         self.flipbook_output.print_info()
-        print()
-        print((f"Extracting frames from {self.video_source.filename} '"
-               f"'at {self.flipbook_output.frame_rate} FPS\n"))
+        print('\n')
+        print((f'Extracting frames from {self.video_source.filename} '
+               f'at {self.flipbook_output.frame_rate} FPS'))
 
 
     def extract_frames(self) -> None:
@@ -135,11 +137,12 @@ class Flipbook:
         if not cam.isOpened():
             raise RuntimeError(f"Failed to open video file: {self.video_source.filename}")
 
+        # expected number of frames after resampling
+        output_frames = round(self.video_source.total_frames * self.output_frame_rate / self.input_frame_rate)
         self.frames.clear()
         for frame in self.frame_generator(self.video_frame_source(cam)):
             self.frames.append(frame)
 
-        self.video_source.total_frames = len(self.frames)
         cam.release()
         cv2.destroyAllWindows()
 
@@ -157,7 +160,7 @@ class Flipbook:
         if not self.frames:
             raise ValueError("No frames extracted. Run extract_frames() before saving.")
 
-        print(f"Saving flipbook to {output_dir} with paper type {paper_type} at {dpi} DPI.")
+        print(f"Saving printable flipbook to {output_dir} with paper type {paper_type} at {dpi} DPI.")
 
         printer = FlipbookPrinter(
             self.frames,

--- a/src/core/flipbook_output.py
+++ b/src/core/flipbook_output.py
@@ -63,6 +63,7 @@ class FlipbookOutput:
 
     def print_info(self):
         print(f'Flipbook frame size: {self.res}')
-        print(f'frame_border_padding: {self.border_padding}')
-        print(f'frame_left_padding: {self.left_padding}')
+        print(f'border_padding: {self.border_padding}')
+        print(f'left_padding: {self.left_padding}')
+        print(f'border_line_width: {self.border_line_width}')
 

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -59,9 +59,14 @@ class FlipbookPrinter:
 
     def save(self) -> None:
         """Generates and saves the flipbook PDF."""
+        self.print_info()
         self.__create_output_dir()
         self.__write_pages()
         self.__combine_pdfs()
+
+    @property
+    def output_file(self):
+        return self.__get_output_name()
 
     def __create_output_dir(self) -> None:
         '''
@@ -130,7 +135,8 @@ class FlipbookPrinter:
         '''
         for page_no in tqdm(
                 range(self.num_pages_to_print),
-                total=self.num_pages_to_print):
+                total=self.num_pages_to_print,
+                desc='Saving printable flipbook'):
             # Get subset of frames for the batch
             start_frame = page_no * self.num_per_page
             end_frame = (page_no + 1) * self.num_per_page - 1
@@ -146,7 +152,7 @@ class FlipbookPrinter:
         and cleans up temporary files.
         '''
         output_frames = [self.__get_output_name(page_no) for page_no in range(self.num_pages_to_print)]
-        output_file_name = self.__get_output_name(None)
+        output_file_name = self.output_file
         merger = PdfWriter()
         for page in output_frames:
             merger.append(page)
@@ -156,3 +162,17 @@ class FlipbookPrinter:
         for page in output_frames:
             os.remove(page)
         print(f'\nWrote {output_file_name}\n\n')
+
+    def print_info(self):
+        print('----------------------------')
+        print('Printable Flipbook Specs')
+        print('----------------------------')
+        print(f'Printed page type: {self.paper_type.format.name}')
+        print(f'Printed page size (inches): {self.paper_type.format.size}')
+        print(f'Printed page size (pixels): {self.paper_type.format.res}')
+        print(f'Printed page dpi: {self.dpi}')
+        print(f'Frames per page: {self.nrows}x{self.ncols}')
+        print(f'Pages to print: {self.num_pages_to_print}')
+        print(f'Output file: {self.output_file}')
+        print('----------------------------')
+        print('\n')


### PR DESCRIPTION
Updated prints to stdout during script for better readability.

Script terminal output now reads as follows:

```
python create_flipbook.py input_videos/steamboat_willie_mickey.mov flipbook_output/mickey -fr 3 -W 5 -H 3 -bp 30 -lp 180 -lw 3
----------------------------
Input Video Info
----------------------------
Input file: input_videos/steamboat_willie_mickey.mov
Resolution: 1726.0x1298.0
Frame rate: 59.34 fps

----------------------------
Output Flipbook Format
----------------------------
Flipbook frame size: 1500x900
border_padding: 30
left_padding: 180
border_line_width: 3


Extracting frames from input_videos/steamboat_willie_mickey.mov at 3.0 FPS
 98%|█████████████████████████████████████████████████████████████████████████▊ | 441/448 [00:03<00:00, 142.63it/s]
   ...Stopping extraction at frame 441.
   ...Done extracting frames.


Saving printable flipbook to flipbook_output/mickey with paper type letter at 300 DPI.
----------------------------
Printable Flipbook Specs
----------------------------
Printed page type: US Letter
Printed page size (inches): 11.0x8.5
Printed page size (pixels): 3300x2550
Printed page dpi: 300
Frames per page: 2x2
Pages to print: 6
Output file: flipbook_output/mickey/steamboat_willie_mickey.pdf
----------------------------


Saving printable flipbook: 100%|█████████████████████████████████████████████████████| 6/6 [00:02<00:00,  2.68it/s]


Wrote flipbook_output/mickey/steamboat_willie_mickey.pdf


```
