### PR TITLE
Paste frames in centre of page when printing

### DIFF
--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -1,8 +1,7 @@
 import os
 
 from math import ceil
-from pathlib import Path
-from typing import Optional, List, Tuple
+from typing import List, Tuple
 
 from PIL import Image
 from pypdf import PdfWriter
@@ -61,37 +60,13 @@ class FlipbookPrinter:
     def save(self) -> None:
         """Generates and saves the flipbook PDF."""
         self.print_info()
-        self.__create_output_dir()
+        FlipbookHelper.create_output_dir(self.output_dir)
         self.__write_pages()
         self.__combine_pdfs()
 
     @property
     def output_file(self):
-        return self.__get_output_name()
-
-    def __create_output_dir(self) -> None:
-        '''
-        Ensures that the output directory exists and is empty.
-        '''
-        output_dir_path = Path(self.output_dir)
-
-        # Validate the output directory before creating it
-        FlipbookHelper.validate_output_dir(output_dir_path)
-
-        # If the directory does not exist, create it (and all parent directories if necessary)
-        output_dir_path.mkdir(parents=True, exist_ok=True)
-        return
-
-    def __get_output_name(self, page_no: Optional[int] = None) -> Path:
-        '''
-        Returns the filename for a given page number,
-        or the final PDF if no page number is given.
-        '''
-        if page_no is None:
-            filename = f'{self.base_name}.pdf'
-        else:
-            filename = f'{self.base_name}.{str(page_no)}.pdf'
-        return Path(self.output_dir).joinpath(Path(filename))
+        return FlipbookHelper.get_output_name(self.base_name, self.output_dir)
 
     def __get_offset(self, frame_no: int) -> Tuple[int, int]:
         '''Computes the offset position for a frame on the page.'''
@@ -107,7 +82,7 @@ class FlipbookPrinter:
 
     def __write_page(self, frames: List[Frame], frame_no: int) -> None:
         '''Generates and saves an individual page with the given frames.'''
-        page_filename = self.__get_output_name(frame_no)
+        page_filename = FlipbookHelper.get_output_name(self.base_name, self.output_dir, frame_no)
         page = Image.new('RGB',
                          (self.paper_type.format.width, self.paper_type.format.height),
                          'white')
@@ -148,7 +123,8 @@ class FlipbookPrinter:
         Combines all individual pages into a single PDF
         and cleans up temporary files.
         '''
-        output_frames = [self.__get_output_name(page_no) for page_no in range(self.num_pages_to_print)]
+        output_frames = [FlipbookHelper.get_output_name(self.base_name, self.output_dir, page_no)\
+                         for page_no in range(self.num_pages_to_print)]
         output_file_name = self.output_file
         merger = PdfWriter()
         for page in output_frames:

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from src.core.frame import Frame
 from src.core.flipbook_output import FlipbookOutput
 from src.helpers.flipbook_helper import FlipbookHelper
+from src.media.padding import Padding, HorizontalPadding, VerticalPadding
 from src.paper.paper_type import PaperType
 
 
@@ -47,26 +48,51 @@ class FlipbookPrinter:
         self.output_dir = output_dir
         self.base_name = base_name
 
-        # Compute the number of rows and columns that fit on a page
-        self.nrows = int(self.paper_type.format.height //
-                         self.flipbook_output.height)
-        self.ncols = int(self.paper_type.format.width //
-                         self.flipbook_output.width)
-        self.num_per_page = self.nrows * self.ncols
-
-        # Calculate the total number of pages required
-        self.num_pages_to_print = ceil(len(self.frames) / self.num_per_page)
-
     def save(self) -> None:
         """Generates and saves the flipbook PDF."""
         self.print_info()
-        FlipbookHelper.create_output_dir(self.output_dir)
+        self.__create_output_dir()
         self.__write_pages()
         self.__combine_pdfs()
 
     @property
+    def nrows(self):
+        return int(self.height // self.flipbook_output.height)
+
+    @property
+    def ncols(self):
+        return int(self.width // self.flipbook_output.width)
+
+    @property
+    def num_per_page(self):
+        # Compute the number of rows and columns that fit on a page
+        return self.nrows * self.ncols
+
+    @property
+    def num_pages_to_print(self):
+        # Calculate the total number of pages required
+        return ceil(len(self.frames) / self.num_per_page)
+
+    @property
+    def width(self):
+        return self.paper_type.format.width
+
+    @property
+    def height(self):
+        return self.paper_type.format.height
+
+    @property
     def output_file(self):
         return FlipbookHelper.get_output_name(self.base_name, self.output_dir)
+
+    @property
+    def page_padding(self) -> Padding:
+        horiz_padding = self.width - self.ncols * self.flipbook_output.width
+        vert_padding = self.height - self.nrows * self.flipbook_output.height
+        return HorizontalPadding(horiz_padding) + VerticalPadding(vert_padding)
+
+    def __create_output_dir(self):
+        return FlipbookHelper.create_output_dir(self.output_dir)
 
     def __get_offset(self, frame_no: int) -> Tuple[int, int]:
         '''Computes the offset position for a frame on the page.'''
@@ -75,17 +101,15 @@ class FlipbookPrinter:
         row = rel_frame_no // self.ncols
         col = rel_frame_no % self.ncols
 
-        offset_width = self.flipbook_output.width * col
-        offset_height = self.flipbook_output.height * row
+        offset_width = self.page_padding.left + self.flipbook_output.width * col
+        offset_height = self.page_padding.top + self.flipbook_output.height * row
 
         return offset_width, offset_height
 
     def __write_page(self, frames: List[Frame], frame_no: int) -> None:
         '''Generates and saves an individual page with the given frames.'''
         page_filename = FlipbookHelper.get_output_name(self.base_name, self.output_dir, frame_no)
-        page = Image.new('RGB',
-                         (self.paper_type.format.width, self.paper_type.format.height),
-                         'white')
+        page = Image.new('RGB', (self.width, self.height), 'white')
 
         for frame in frames:
             # get image data for full frame including padding

--- a/src/helpers/flipbook_helper.py
+++ b/src/helpers/flipbook_helper.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 
 class FlipbookHelper:
@@ -13,3 +14,29 @@ class FlipbookHelper:
                 raise IsADirectoryError(f'Output directory {pathname} exists but is not a directory.')
             if any(pathname.iterdir()):
                 raise FileExistsError(f'Output directory {pathname} exists and is nonempty.')
+
+    @staticmethod
+    def create_output_dir(output_dir) -> None:
+        '''
+        Ensures that the output directory exists and is empty.
+        '''
+        output_dir_path = Path(output_dir)
+
+        # Validate the output directory before creating it
+        FlipbookHelper.validate_output_dir(output_dir_path)
+
+        # If the directory does not exist, create it (and all parent directories if necessary)
+        output_dir_path.mkdir(parents=True, exist_ok=True)
+        return
+
+    @staticmethod
+    def get_output_name(base_name, output_dir, page_no: Optional[int] = None) -> Path:
+        '''
+        Returns the filename for a given page number,
+        or the final PDF if no page number is given.
+        '''
+        if page_no is None:
+            filename = f'{base_name}.pdf'
+        else:
+            filename = f'{base_name}.{str(page_no)}.pdf'
+        return Path(output_dir).joinpath(Path(filename))

--- a/src/media/padding.py
+++ b/src/media/padding.py
@@ -56,13 +56,15 @@ class VerticalPadding(Padding):
 
 class HorizontalPadding(Padding):
     '''
-    Add padding horizontally to flipbook.
-    For flipbook, keep the image as close as possible
-    to the right edge, so add the horizontal padding
-    to left side only
+    Add padding to be split between left and right
     '''
     def __init__(self, pad: int) -> None:
-        super().__init__(pad, 0, 0, 0)
+        left = pad//2
+        right = pad//2
+        if pad % 2 == 1:
+            # if it's an odd number, put the extra pixel on the lef
+            left += 1
+        super().__init__(left, right, 0, 0)
 
 
 class ZeroPadding(EqualPadding):

--- a/src/media/resizer.py
+++ b/src/media/resizer.py
@@ -1,5 +1,5 @@
 from src.media.resolution import Resolution
-from src.media.padding import HorizontalPadding
+from src.media.padding import LeftPadding
 from src.media.padding import VerticalPadding
 
 class Resizer:
@@ -23,7 +23,10 @@ class Resizer:
         if self.fit_to_height:
             resize_height = self.canvas_res.height
             resize_width = int(resize_height / self.input_aspect)
-            padding = HorizontalPadding(self.canvas_res.width - resize_width)
+            # When fitting to height, we want the image to be as far
+            # to the right of the book as possible (for left-bound book)
+            # so use LeftPadding instead of HorizontalPadding
+            padding = LeftPadding(self.canvas_res.width - resize_width)
         else:
             resize_width = self.canvas_res.width
             resize_height = int(resize_width * self.input_aspect)

--- a/test/test_flipbook_printer.py
+++ b/test/test_flipbook_printer.py
@@ -4,12 +4,21 @@ from pathlib import Path
 from src.core.flipbook_printer import FlipbookPrinter
 from src.core.frame import Frame
 from src.core.flipbook_output import FlipbookOutput
+from src.helpers.flipbook_helper import FlipbookHelper
+from src.media.padding import HorizontalPadding, VerticalPadding
+from src.media.resolution import Resolution
+from src.media.size import Size
 from src.paper.paper_format import PaperFormat
 from src.paper.paper_type import PaperType
 
 
 class TestFlipbookPrinter(unittest.TestCase):
     mock_paper_format_name = 'US Letter'
+    frame_width_in = 5
+    frame_height_in = 3
+    page_width_in = 11
+    page_height_in = 8.5
+    dpi = 300
 
     def get_frame(self, frame_no):
         mock_frame = MagicMock(spec=Frame)
@@ -17,19 +26,34 @@ class TestFlipbookPrinter(unittest.TestCase):
         return mock_frame
 
     def setUp(self):
-        self.mock_frames = [self.get_frame(frame_no) for frame_no in range(10)]
         self.mock_flipbook_output = MagicMock(spec=FlipbookOutput)
-        self.mock_flipbook_output.width = 2
-        self.mock_flipbook_output.height = 3
+        self.mock_flipbook_output.size = Size(
+                                         self.frame_width_in,
+                                         self.frame_height_in
+                                         )
+        self.mock_flipbook_output.width = self.frame_width_in * self.dpi
+        self.mock_flipbook_output.height = self.frame_height_in * self.dpi
+        self.mock_flipbook_output.res = Resolution(
+                                        self.frame_width_in * self.dpi,
+                                        self.frame_height_in * self.dpi
+                                        )
         self.mock_paper_format = MagicMock(spec=PaperFormat)
         self.mock_paper_format.name = self.mock_paper_format_name
-        self.mock_paper_format.width = 11
-        self.mock_paper_format.height = 8.5
+        self.mock_paper_format.size = Size(
+                                      self.page_width_in,
+                                      self.page_height_in
+                                      )
+        self.mock_paper_format.res = Resolution(
+                                      self.page_width_in * self.dpi,
+                                      int(self.page_height_in * self.dpi)
+                                      )
         self.mock_paper_type = MagicMock(spec=PaperType)
         self.mock_paper_type.format = self.mock_paper_format
 
         self.output_dir = "test_output"
         self.base_name = "flipbook_test"
+
+        self.mock_frames = [self.get_frame(frame_no) for frame_no in range(10)]
 
         self.flipbook_printer = FlipbookPrinter(
             self.mock_frames,
@@ -60,22 +84,36 @@ class TestFlipbookPrinter(unittest.TestCase):
     def test_get_output_name(self):
         """Tests that output file names are generated correctly."""
         self.assertEqual(
-            self.flipbook_printer._FlipbookPrinter__get_output_name(1),
+            FlipbookHelper.get_output_name(self.flipbook_printer.base_name, self.flipbook_printer.output_dir, 1),
             Path(self.output_dir) / "flipbook_test.1.pdf"
         )
         self.assertEqual(
-            self.flipbook_printer._FlipbookPrinter__get_output_name(),
+            self.flipbook_printer.output_file,
             Path(self.output_dir) / "flipbook_test.pdf"
         )
 
 
     def test_get_offset(self):
         """Tests that frame offsets are calculated correctly."""
-        self.flipbook_printer.ncols = 5
-        self.flipbook_printer.num_per_page = 10
-        offset_x, offset_y = self.flipbook_printer._FlipbookPrinter__get_offset(6)
-        self.assertEqual(offset_x, self.mock_flipbook_output.width * 1)
-        self.assertEqual(offset_y, self.mock_flipbook_output.height * 1)
+        offset_x, offset_y = self.flipbook_printer._FlipbookPrinter__get_offset(1)
+
+        rel_frame_no = 1 % self.flipbook_printer.num_per_page
+
+        row = rel_frame_no // self.flipbook_printer.ncols
+        col = rel_frame_no % self.flipbook_printer.ncols
+
+        horiz_padding = self.flipbook_printer.width - \
+                        self.flipbook_printer.ncols * self.flipbook_printer.flipbook_output.width
+        vert_padding = self.flipbook_printer.height - \
+                       self.flipbook_printer.nrows * self.flipbook_printer.flipbook_output.height
+
+        offset_width = HorizontalPadding(horiz_padding).left + \
+                       self.flipbook_printer.flipbook_output.width * col
+        offset_height = VerticalPadding(vert_padding).top + \
+                        self.flipbook_printer.flipbook_output.height * row
+
+        self.assertEqual(offset_x, offset_width)
+        self.assertEqual(offset_y, offset_height)
 
     @patch("PIL.Image.new")
     @patch("PIL.Image.Image.paste")
@@ -91,7 +129,6 @@ class TestFlipbookPrinter(unittest.TestCase):
     @patch("pypdf.PdfWriter.close")
     def test_combine_pdfs(self, mock_close, mock_write, mock_append, mock_remove):
         """Tests that PDF merging is performed correctly."""
-        self.flipbook_printer.num_pages_to_print = 3
         self.flipbook_printer._FlipbookPrinter__combine_pdfs()
         self.assertEqual(mock_append.call_count, 3)
         mock_write.assert_called_once()

--- a/test/test_padding.py
+++ b/test/test_padding.py
@@ -38,8 +38,8 @@ class TestPadding(unittest.TestCase):
 
     def test_horizontal_padding(self):
         padding = HorizontalPadding(7)
-        self.assertEqual(padding.left, 7)
-        self.assertEqual(padding.right, 0)
+        self.assertEqual(padding.left, 4)
+        self.assertEqual(padding.right, 3)
         self.assertEqual(padding.top, 0)
         self.assertEqual(padding.bottom, 0)
 

--- a/test/test_resizer.py
+++ b/test/test_resizer.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock
 from src.media.resolution import Resolution
-from src.media.padding import HorizontalPadding, VerticalPadding
+from src.media.padding import VerticalPadding, LeftPadding
 from src.media.resizer import Resizer
 
 
@@ -13,7 +13,7 @@ class TestResizer(unittest.TestCase):
 
         expected_width = int(600 / (16 / 9))  # height / aspect ratio
         expected_height = 600  # matches canvas height
-        expected_padding = HorizontalPadding(canvas_res.width - expected_width)
+        expected_padding = LeftPadding(canvas_res.width - expected_width)
 
         self.assertEqual(resizer.resize_res, Resolution(expected_width, expected_height))
         self.assertEqual(resizer.padding, expected_padding)


### PR DESCRIPTION
When printing the flipbook frames on paper for printing, the tiling started in the upper left hand corner with no border on the left/top.  This change adjusts the page margins so that the frames are tiled in the centre of the page.

Changes are:
1. Centre flipbook frames on the printable page
2. HorizontalPadding class used to put all the horizontal padding on the left, but since we already have a LeftPadding class that does this, and we now need a Padding subclass that splits the padding between left and right margins, updated HorizaontalPadding to split the horizontal white space between left and right margins, 
3. Update unit tests accordingly.

