### PR TITLE
make resolution a property for FlipbookOutput and PaperFormat

### DIFF
--- a/src/core/flipbook_output.py
+++ b/src/core/flipbook_output.py
@@ -20,9 +20,6 @@ class FlipbookOutput:
         # frame size in inches
         self.size = Size(width, height)
 
-        # frame resolution in pixels
-        self.res = self.size.get_resolution(dpi)
-
         # padding around the frame
         self.border_padding = border_padding
 
@@ -33,6 +30,11 @@ class FlipbookOutput:
         self.border_line_width = border_line_width
 
         self.dpi = dpi
+
+    @property
+    def res(self):
+        # frame resolution in pixels
+        return self.size.get_resolution(self.dpi)
 
     @property
     def width(self):

--- a/src/paper/paper_format.py
+++ b/src/paper/paper_format.py
@@ -12,8 +12,11 @@ class PaperFormat:
                  dpi: int = 300):
         self.name = name
         self.size = Size(width, height)
-        self.res = self.size.get_resolution(dpi)
         self.dpi = dpi
+
+    @property
+    def res(self):
+        return self.size.get_resolution(self.dpi)
 
     @property
     def aspect(self) -> float:

--- a/test/test_flipbook_printer.py
+++ b/test/test_flipbook_printer.py
@@ -33,7 +33,7 @@ class TestFlipbookPrinter(unittest.TestCase):
                                          )
         self.mock_flipbook_output.width = self.frame_width_in * self.dpi
         self.mock_flipbook_output.height = self.frame_height_in * self.dpi
-        self.mock_flipbook_output.res = Resolution(
+        self.mock_flipbook_output.size = Size(
                                         self.frame_width_in * self.dpi,
                                         self.frame_height_in * self.dpi
                                         )
@@ -42,10 +42,6 @@ class TestFlipbookPrinter(unittest.TestCase):
         self.mock_paper_format.size = Size(
                                       self.page_width_in,
                                       self.page_height_in
-                                      )
-        self.mock_paper_format.res = Resolution(
-                                      self.page_width_in * self.dpi,
-                                      int(self.page_height_in * self.dpi)
                                       )
         self.mock_paper_type = MagicMock(spec=PaperType)
         self.mock_paper_type.format = self.mock_paper_format


### PR DESCRIPTION
make resolution a property for FlipbookOutput and PaperFormat
(previously was set as a class variable in __init__)