### PR TITLE
Create page orientation class, and adjust watermark size and location

### DIFF
--- a/src/core/flipbook.py
+++ b/src/core/flipbook.py
@@ -31,6 +31,7 @@ class Flipbook:
 
     @property
     def input_file(self):
+        # input file name of video source
         return self.video_source.filename
 
     @property

--- a/src/core/flipbook_output.py
+++ b/src/core/flipbook_output.py
@@ -32,6 +32,10 @@ class FlipbookOutput:
         self.dpi = dpi
 
     @property
+    def aspect(self):
+        return self.size.aspect
+
+    @property
     def res(self) -> Resolution:
         # frame resolution in pixels
         return self.size.get_resolution(self.dpi)

--- a/src/core/flipbook_output.py
+++ b/src/core/flipbook_output.py
@@ -32,24 +32,30 @@ class FlipbookOutput:
         self.dpi = dpi
 
     @property
-    def res(self):
+    def res(self) -> Resolution:
         # frame resolution in pixels
         return self.size.get_resolution(self.dpi)
 
     @property
-    def width(self):
+    def width(self) -> int:
+        # frame width in pixels
         return self.res.width
 
     @property
-    def height(self):
+    def height(self) -> int:
+        # frame height in pixels
         return self.res.height
 
     @property
     def padding(self) -> Padding:
+        '''
+        user-input padding (border padding + left-hand padding for binding)
+        values in pixels
+        '''
         # Adjust padding to avoid double application of border padding
         adjusted_padding = max(0, self.border_padding - self.border_line_width)
 
-        # Compute frame padding
+        # Compute additive frame padding
         return EqualPadding(adjusted_padding) + LeftPadding(self.left_padding)
 
     @property
@@ -63,7 +69,7 @@ class FlipbookOutput:
         height = self.res.height - vert_padding
         return Resolution(width, height)
 
-    def print_info(self):
+    def print_info(self) -> None:
         print(f'Flipbook frame size: {self.res}')
         print(f'border_padding: {self.border_padding}')
         print(f'left_padding: {self.left_padding}')

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -12,6 +12,8 @@ from src.core.frame import Frame
 from src.core.flipbook_output import FlipbookOutput
 from src.helpers.flipbook_helper import FlipbookHelper
 from src.media.padding import Padding, HorizontalPadding, VerticalPadding
+from src.paper.orientation import Orientation
+from src.paper.paper_format import PaperFormat
 from src.paper.paper_type import PaperType
 
 
@@ -49,6 +51,24 @@ class FlipbookPrinter:
         self.output_dir = output_dir
         self.base_name = base_name
 
+        self.paper_orientation = self.__get_orientation()
+
+    def __get_orientation(self) -> Orientation:
+        '''
+        check which orientation leads to the fewest number of
+        output pages, and return that orientation.
+        '''
+        portrait_paper = self.paper_type.format(Orientation.PORTRAIT)
+        landscape_paper = self.paper_type.format(Orientation.LANDSCAPE)
+        if self.get_num_per_page(portrait_paper) >= self.get_num_per_page(landscape_paper):
+            return Orientation.PORTRAIT
+        return Orientation.LANDSCAPE
+
+    def get_num_per_page(self, paper_format: PaperFormat):
+        nrows = int(paper_format.height // self.flipbook_output.height)
+        ncols = int(paper_format.width // self.flipbook_output.width)
+        return nrows * ncols
+
     def save(self) -> None:
         """Generates and saves the flipbook PDF."""
         self.print_info()
@@ -79,12 +99,12 @@ class FlipbookPrinter:
     @property
     def width(self) -> int:
         # page width in pixels
-        return self.paper_type.format.width
+        return self.paper_type.format(self.paper_orientation).width
 
     @property
     def height(self) -> int:
         # page height in pixels
-        return self.paper_type.format.height
+        return self.paper_type.format(self.paper_orientation).height
 
     @property
     def output_file(self) -> Path:
@@ -181,9 +201,9 @@ class FlipbookPrinter:
         print('----------------------------')
         print('Printable Flipbook Specs')
         print('----------------------------')
-        print(f'Printed page type: {self.paper_type.format.name}')
-        print(f'Printed page size (inches): {self.paper_type.format.size}')
-        print(f'Printed page size (pixels): {self.paper_type.format.res}')
+        print(f'Printed page type: {self.paper_type.format(self.paper_orientation).name}')
+        print(f'Printed page size (inches): {self.paper_type.format(self.paper_orientation).size}')
+        print(f'Printed page size (pixels): {self.paper_type.format(self.paper_orientation).res}')
         print(f'Printed page dpi: {self.dpi}')
         print(f'Frames per page: {self.nrows}x{self.ncols}')
         print(f'Pages to print: {self.num_pages_to_print}')

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -55,22 +55,6 @@ class FlipbookPrinter:
 
         self.paper_orientation = self.__get_orientation()
 
-    def __get_orientation(self) -> Orientation:
-        '''
-        check which orientation leads to the fewest number of
-        output pages, and return that orientation.
-        '''
-        portrait_paper = self.paper_type.format(Orientation.PORTRAIT)
-        landscape_paper = self.paper_type.format(Orientation.LANDSCAPE)
-        if self.get_num_per_page(portrait_paper) >= self.get_num_per_page(landscape_paper):
-            return Orientation.PORTRAIT
-        return Orientation.LANDSCAPE
-
-    def get_num_per_page(self, paper_format: PaperFormat):
-        nrows = int(paper_format.height // self.flipbook_output.height)
-        ncols = int(paper_format.width // self.flipbook_output.width)
-        return nrows * ncols
-
     def save(self) -> None:
         """Generates and saves the flipbook PDF."""
         self.print_info()
@@ -154,6 +138,28 @@ class FlipbookPrinter:
         offset_height = self.page_padding.top + self.flipbook_output.height * row
 
         return offset_width, offset_height
+
+    def __get_orientation(self) -> Orientation:
+        '''
+        check which orientation leads to the fewest number of
+        output pages, and return that orientation.
+        '''
+        portrait_paper = self.paper_type.format(Orientation.PORTRAIT)
+        landscape_paper = self.paper_type.format(Orientation.LANDSCAPE)
+        if self.__get_num_per_page(portrait_paper) >= self.__get_num_per_page(landscape_paper):
+            return Orientation.PORTRAIT
+        return Orientation.LANDSCAPE
+
+    def __get_num_per_page(self, paper_format: PaperFormat) -> int:
+        '''
+        Return the number of frames per page for a given paper format
+
+        Note we can't just use the nrows/ncols property here
+        because we use this method to determine the paper orientation
+        '''
+        nrows = int(paper_format.height // self.flipbook_output.height)
+        ncols = int(paper_format.width // self.flipbook_output.width)
+        return nrows * ncols
 
     def __write_page(self, frames: List[Frame], frame_no: int) -> None:
         '''Generates and saves an individual page with the given frames.'''

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -202,6 +202,7 @@ class FlipbookPrinter:
         print('Printable Flipbook Specs')
         print('----------------------------')
         print(f'Printed page type: {self.paper_type.format(self.paper_orientation).name}')
+        print(f'Printed page type: {self.paper_orientation.name}')
         print(f'Printed page size (inches): {self.paper_type.format(self.paper_orientation).size}')
         print(f'Printed page size (pixels): {self.paper_type.format(self.paper_orientation).res}')
         print(f'Printed page dpi: {self.dpi}')

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -1,6 +1,7 @@
 import os
 
 from math import ceil
+from pathlib import Path
 from typing import List, Tuple
 
 from PIL import Image
@@ -56,42 +57,58 @@ class FlipbookPrinter:
         self.__combine_pdfs()
 
     @property
-    def nrows(self):
+    def nrows(self) -> int:
+        # number of rows of frames on a given page
         return int(self.height // self.flipbook_output.height)
 
     @property
-    def ncols(self):
+    def ncols(self) -> int:
+        # number of columns of frames on a given page
         return int(self.width // self.flipbook_output.width)
 
     @property
-    def num_per_page(self):
+    def num_per_page(self) -> int:
         # Compute the number of rows and columns that fit on a page
         return self.nrows * self.ncols
 
     @property
-    def num_pages_to_print(self):
+    def num_pages_to_print(self) -> int:
         # Calculate the total number of pages required
         return ceil(len(self.frames) / self.num_per_page)
 
     @property
-    def width(self):
+    def width(self) -> int:
+        # page width in pixels
         return self.paper_type.format.width
 
     @property
-    def height(self):
+    def height(self) -> int:
+        # page height in pixels
         return self.paper_type.format.height
 
     @property
-    def output_file(self):
+    def output_file(self) -> Path:
+        '''
+        Name of the output PDF file that contains the combined pages of
+        tiled frames
+        '''
         return FlipbookHelper.get_output_name(self.base_name, self.output_dir)
 
     @property
     def page_padding(self) -> Padding:
+        '''
+        Calculate how much white space is left over on the page once
+        the nrows x ncols frames have been accounted for, and return
+        a Padding object that would place the frames centred on the page.
+        '''
         horiz_padding = self.width - self.ncols * self.flipbook_output.width
         vert_padding = self.height - self.nrows * self.flipbook_output.height
         return HorizontalPadding(horiz_padding) + VerticalPadding(vert_padding)
 
-    def __create_output_dir(self):
+    def __create_output_dir(self) -> None:
+        '''
+        Create directory self.output_dir after performing validating
+        '''
         return FlipbookHelper.create_output_dir(self.output_dir)
 
     def __get_offset(self, frame_no: int) -> Tuple[int, int]:

--- a/src/core/flipbook_printer.py
+++ b/src/core/flipbook_printer.py
@@ -12,6 +12,8 @@ from src.core.frame import Frame
 from src.core.flipbook_output import FlipbookOutput
 from src.helpers.flipbook_helper import FlipbookHelper
 from src.media.padding import Padding, HorizontalPadding, VerticalPadding
+from src.media.resolution import Resolution
+from src.media.size import Size
 from src.paper.orientation import Orientation
 from src.paper.paper_format import PaperFormat
 from src.paper.paper_type import PaperType
@@ -95,6 +97,16 @@ class FlipbookPrinter:
     def num_pages_to_print(self) -> int:
         # Calculate the total number of pages required
         return ceil(len(self.frames) / self.num_per_page)
+
+    @property
+    def size(self) -> Size:
+        # page width in pixels
+        return self.paper_type.format(self.paper_orientation).size
+
+    @property
+    def res(self) -> Resolution:
+        # page width in pixels
+        return self.paper_type.format(self.paper_orientation).res
 
     @property
     def width(self) -> int:
@@ -202,9 +214,9 @@ class FlipbookPrinter:
         print('Printable Flipbook Specs')
         print('----------------------------')
         print(f'Printed page type: {self.paper_type.format(self.paper_orientation).name}')
-        print(f'Printed page type: {self.paper_orientation.name}')
-        print(f'Printed page size (inches): {self.paper_type.format(self.paper_orientation).size}')
-        print(f'Printed page size (pixels): {self.paper_type.format(self.paper_orientation).res}')
+        print(f'Printed page orientation: {self.paper_orientation.name}')
+        print(f'Printed page size (inches): {self.size}')
+        print(f'Printed page size (pixels): {self.res}')
         print(f'Printed page dpi: {self.dpi}')
         print(f'Frames per page: {self.nrows}x{self.ncols}')
         print(f'Pages to print: {self.num_pages_to_print}')

--- a/src/core/frame.py
+++ b/src/core/frame.py
@@ -32,19 +32,24 @@ class Frame:
         self.padding = self.flipbook_output.padding + self.canvas.padding
 
     @property
-    def input_aspect(self):
+    def input_aspect(self) -> float:
+        # aspect ratio of the canvas
         return self.canvas.input_aspect
 
     @property
-    def output_width(self):
+    def output_width(self) -> int:
+        # width of the flipbook frames in pixels
         return self.flipbook_output.width
 
     @property
-    def output_height(self):
+    def output_height(self) -> int:
+        # height of the flipbook frames in pixels
         return self.flipbook_output.height
 
     @property
-    def frame_border_line_width(self):
+    def frame_border_line_width(self) -> int:
+        # width in pixels of the line drawn around
+        # the border of each frame
         return self.flipbook_output.border_line_width
 
     def get_frame(self) -> Image.Image:
@@ -77,7 +82,10 @@ class Frame:
         return frame
 
     def __add_watermark_to_img(self, img: Image.Image, loc: Tuple[int, int]) -> None:
-        # Add the frame number as a watermark text on the bottom left corner
+        '''
+        Add the frame number as a watermark text on the bottom left corner
+        '''
+
         watermark_text = str(self.frame_no + 1)
         draw = ImageDraw.Draw(img)
 

--- a/src/core/frame.py
+++ b/src/core/frame.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageOps
 from PIL import ImageDraw
 from PIL import ImageFont
 
+from src.helpers.flipbook_helper import FlipbookHelper
 from src.media.canvas import Canvas
 from src.helpers.flipbook_constants import FlipbookConstants
 from src.core.flipbook_output import FlipbookOutput
@@ -73,19 +74,25 @@ class Frame:
         frame = ImageOps.expand(frame, border=self.frame_border_line_width, fill='black')
 
         # Add watermark to the frame
-        # Position at bottom left-hand corner of the image
-        # Add left padding to match the bottom padding
-        x_pos = self.padding.bottom
-        y_pos = self.flipbook_output.height - self.padding.bottom
-
-        self.__add_watermark_to_img(frame, (x_pos, y_pos))
+        self.__add_watermark_to_img(frame)
         return frame
 
-    def __add_watermark_to_img(self, img: Image.Image, loc: Tuple[int, int]) -> None:
+    def __get_fontsize(self) -> int:
+        return FlipbookHelper.get_fontsize(self.flipbook_output.res)
+
+    def __get_watermark_location(self, text_width: int, text_height: int) \
+            -> Tuple[int, int]:
+        # Position at bottom left-hand corner of the image
+        # Add left padding to match the bottom padding
+        x_pos = int(self.padding.right / 2.0)
+        y_pos = int(self.flipbook_output.height - self.padding.bottom/2.0)
+        y_pos = y_pos - 2 * text_height
+        return x_pos, y_pos
+
+    def __add_watermark_to_img(self, img: Image.Image) -> None:
         '''
         Add the frame number as a watermark text on the bottom left corner
         '''
-
         watermark_text = str(self.frame_no + 1)
         draw = ImageDraw.Draw(img)
 
@@ -93,7 +100,7 @@ class Frame:
         try:
             font = ImageFont.truetype(
                 FlipbookConstants.Font.DEFAULT,
-                FlipbookConstants.Font.SIZE)
+                self.__get_fontsize())
         except (OSError, IOError):
             print((f'Unable to load font {FlipbookConstants.Font.DEFAULT}.'
                   '  loading default font'))
@@ -104,7 +111,7 @@ class Frame:
         text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
 
         # position at bottom left-hand corner of frame
-        position = (loc[0], loc[1] - text_height)
+        position = self.__get_watermark_location(text_width, text_height)
 
         # Draw the watermark
         draw.text(position, watermark_text, font=font, fill='black')

--- a/src/core/video_source.py
+++ b/src/core/video_source.py
@@ -61,6 +61,7 @@ class VideoSource:
 
     @property
     def aspect(self) -> float:
+        # aspect ratio of the source video file
         return float(self.height)/float(self.width)
 
     def get_base_name(self) -> str:

--- a/src/helpers/flipbook_constants.py
+++ b/src/helpers/flipbook_constants.py
@@ -1,3 +1,5 @@
+from src.media.resolution import Resolution
+
 
 class FlipbookConstants:
     class Video:
@@ -6,4 +8,6 @@ class FlipbookConstants:
     class Font:
         DEFAULT = 'fonts/arial.ttf'
         SIZE = 50
+        # resolution for which SIZE is appropriate
+        REF_RES = Resolution(1500, 900)
 

--- a/src/helpers/flipbook_helper.py
+++ b/src/helpers/flipbook_helper.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 from typing import Optional
+import math
+
+from src.helpers.flipbook_constants import FlipbookConstants
+from src.media.resolution import Resolution
 
 
 class FlipbookHelper:
@@ -40,3 +44,19 @@ class FlipbookHelper:
         else:
             filename = f'{base_name}.{str(page_no)}.pdf'
         return Path(output_dir).joinpath(Path(filename))
+
+    @staticmethod
+    def get_fontsize(output_res: Resolution) -> int:
+        '''
+        Return the font size for frame # watermark, appropriately scaled
+        Scale using sqrt of height or width ratio to prevent drastic scaling
+        '''
+        reference_res = FlipbookConstants.Font.REF_RES
+        if reference_res.aspect >= output_res.aspect:
+            # compare heights
+            scale_factor = math.sqrt(output_res.height / reference_res.height)
+        else:
+            # compare widths
+            scale_factor = math.sqrt(output_res.width / reference_res.width)
+        return int(FlipbookConstants.Font.SIZE * scale_factor)
+

--- a/src/media/resizer.py
+++ b/src/media/resizer.py
@@ -9,7 +9,7 @@ class Resizer:
                  ):
         self.input_aspect = input_aspect
         self.canvas_res = canvas_res
-        self.resize_res, self.padding = self._compute_resize()
+        self.resize_res, self.padding = self.__compute_resize()
 
     @property
     def aspect(self) -> float:
@@ -22,7 +22,7 @@ class Resizer:
         # (True -> means fit to height; False -> means fit to width)
         return self.input_aspect > self.aspect
 
-    def _compute_resize(self) -> tuple[Resolution, Padding]:
+    def __compute_resize(self) -> tuple[Resolution, Padding]:
         '''
         return the parameters for resizing the input video frames
         to the size of the output frame canvas

--- a/src/media/resizer.py
+++ b/src/media/resizer.py
@@ -1,5 +1,5 @@
 from src.media.resolution import Resolution
-from src.media.padding import LeftPadding
+from src.media.padding import LeftPadding, Padding
 from src.media.padding import VerticalPadding
 
 class Resizer:
@@ -13,13 +13,20 @@ class Resizer:
 
     @property
     def aspect(self) -> float:
+        # aspect ratio of the canvas area
         return self.canvas_res.aspect
 
     @property
     def fit_to_height(self) -> bool:
+        # fit the input image to the canvas height?
+        # (True -> means fit to height; False -> means fit to width)
         return self.input_aspect > self.aspect
 
-    def _compute_resize(self):
+    def _compute_resize(self) -> tuple[Resolution, Padding]:
+        '''
+        return the parameters for resizing the input video frames
+        to the size of the output frame canvas
+        '''
         if self.fit_to_height:
             resize_height = self.canvas_res.height
             resize_width = int(resize_height / self.input_aspect)

--- a/src/paper/orientation.py
+++ b/src/paper/orientation.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class Orientation(Enum):
+    PORTRAIT = 'Portrait'
+    LANDSCAPE = 'Landscape'

--- a/src/paper/paper_format.py
+++ b/src/paper/paper_format.py
@@ -1,4 +1,6 @@
 from src.media.size import Size
+from src.paper.orientation import Orientation
+
 
 class PaperFormat:
     '''
@@ -9,10 +11,18 @@ class PaperFormat:
                  name: str,
                  width: float,
                  height: float,
-                 dpi: int = 300):
+                 dpi: int = 300,
+                 orientation: Orientation = Orientation.PORTRAIT):
         self.name = name
-        self.size = Size(width, height)
         self.dpi = dpi
+        self.orientation = orientation
+
+        # Adjust size based on orientation
+        if self.orientation == Orientation.PORTRAIT:
+            self.size = Size(width, height)
+        else:
+            # Swap width & height for landscape
+            self.size = Size(height, width)
 
     @property
     def res(self):

--- a/src/paper/paper_type.py
+++ b/src/paper/paper_type.py
@@ -11,7 +11,6 @@ class PaperType(Enum):
     LETTER = ("US Letter", 8.5, 11.0)
     LEGAL = ("US Legal", 8.5, 14.0)
 
-    @property
     def format(self, orientation: Orientation = Orientation.PORTRAIT) -> PaperFormat:
         '''Return a PaperFormat instance for the given paper type.'''
         return PaperFormat(*self.value, orientation=orientation)

--- a/src/paper/paper_type.py
+++ b/src/paper/paper_type.py
@@ -1,4 +1,6 @@
 from enum import Enum
+
+from src.paper.orientation import Orientation
 from src.paper.paper_format import PaperFormat
 
 class PaperType(Enum):
@@ -6,13 +8,13 @@ class PaperType(Enum):
     Type of paper on which the flipbook will be printed.
     Enum members store (name, width, height) and return a PaperFormat instance.
     '''
-    LETTER = ("US Letter", 11.0, 8.5)
-    LEGAL = ("US Legal", 14.0, 8.5)
+    LETTER = ("US Letter", 8.5, 11.0)
+    LEGAL = ("US Legal", 8.5, 14.0)
 
     @property
-    def format(self) -> PaperFormat:
+    def format(self, orientation: Orientation = Orientation.PORTRAIT) -> PaperFormat:
         '''Return a PaperFormat instance for the given paper type.'''
-        return PaperFormat(*self.value)
+        return PaperFormat(*self.value, orientation=orientation)
 
     @staticmethod
     def get(key: str) -> "PaperType":

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -10,6 +10,8 @@ from src.core.frame import Frame
 from src.core.flipbook_output import FlipbookOutput
 from src.media.canvas import Canvas
 from src.media.padding import Padding
+from src.media.resolution import Resolution
+from src.media.size import Size
 
 
 class TestFrame(unittest.TestCase):
@@ -22,6 +24,9 @@ class TestFrame(unittest.TestCase):
         self.mock_canvas = MagicMock(spec=Canvas)
 
         # Define mock attributes
+        self.mock_flipbook_output.dpi = 200
+        self.mock_flipbook_output.size = Size(4, 3)
+        self.mock_flipbook_output.res = Resolution(800, 600)
         self.mock_flipbook_output.width = 800
         self.mock_flipbook_output.height = 600
         self.mock_flipbook_output.padding = Padding(left=150, right=20, bottom=20, top=20)
@@ -88,7 +93,7 @@ class TestFrame(unittest.TestCase):
         mock_draw_instance = MagicMock()
         mock_draw.return_value = mock_draw_instance
 
-        self.frame._Frame__add_watermark_to_img(mock_img, (50, 50))
+        self.frame._Frame__add_watermark_to_img(mock_img)
 
         assert mock_truetype.call_count == 2
         mock_draw.assert_called_once()


### PR DESCRIPTION
This PR creates an Orientation class, checks whether a Portrait or Landscape page orientation will allow for more frames to be printed per page, and selects the more efficient orientation.  It also adjusts the frame number watermark location, and scales the font size based on the output frame size.

Change summary:
* Creates Orientation enum (Portrait, Landscape)
* PaperFormat takes the orientation as an argument and sets the Size based on orientation
* FlipbookPrinter sets the orientation of the page based on how many frames fit in Portrait vs Landscape, selecting the one that allows for most frames per page
* Watermark location tweaked (and logic was pulled into its own method)
* Watermark text size is now scaled based on output frame size, in FlipbookHelpers.get_fontsize()
* Added docstrings